### PR TITLE
Disallow unnecessary double quotes

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -110,5 +110,8 @@
     "non_empty_constructor_needs_parens": {
         "name": "non_empty_constructor_needs_parens",
         "level": "ignore"
+    },
+    "no_unnecessary_double_quotes": {
+        "level": "warn"
     }
 }


### PR DESCRIPTION
Add single quotes rule enforce convention [already documented in styleguide](https://github.com/mavenlink/coffeescript-style-guide#strings).


**Excerpt –**
Prefer single quoted strings (`''`) instead of double quoted (`""`) strings, unless features like string interpolation are being used for the given string.