### PR TITLE
Add braces spacing rule

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -48,6 +48,11 @@
             "right": 1
         }
     },
+    "braces_spacing": {
+      "spaces": 1,
+      "empty_object_spaces": 0,
+      "level": "warn"
+    },
     "no_implicit_braces": {
         "name": "no_implicit_braces",
         "level": "ignore",


### PR DESCRIPTION
Add braces padding rule to enforce convention [already documented in styleguide](https://github.com/mavenlink/coffeescript-style-guide#whitespace-in-expressions-and-statements).

**Excerpt –**
- Always pad object literals with whitespace
```coffeescript
  { property: 'property' } # Yes
  {property: 'property'} # No
```